### PR TITLE
fix - resolve UnnecessaryStubbingException when using MockitoJUnitRunner

### DIFF
--- a/src/main/java/org/camunda/bpm/extension/mockito/query/AbstractQueryMock.java
+++ b/src/main/java/org/camunda/bpm/extension/mockito/query/AbstractQueryMock.java
@@ -61,9 +61,8 @@ abstract class AbstractQueryMock<M extends AbstractQueryMock<M, Q, R, S>, Q exte
   protected AbstractQueryMock(@Nonnull final Class<Q> queryType, @Nonnull final Class<S> serviceType) {
     query = FluentAnswer.createMock(queryType);
     createMethod = createMethod(queryType, serviceType);
-
-    list(new ArrayList<R>());
-    singleResult(null);
+    // No default values for singleResult() and list() anymore, as it is default already
+    // and causes UnnecessaryStubbingException if list() is not used on the stub.
   }
 
   private Method createMethod(@Nonnull final Class<Q> queryType, @Nonnull Class<S> serviceType) {

--- a/src/test/java/org/camunda/bpm/extension/mockito/query/ProcessInstanceQueryMockTest.java
+++ b/src/test/java/org/camunda/bpm/extension/mockito/query/ProcessInstanceQueryMockTest.java
@@ -1,0 +1,52 @@
+package org.camunda.bpm.extension.mockito.query;
+
+import org.assertj.core.util.Lists;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.extension.mockito.CamundaMockito;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProcessInstanceQueryMockTest {
+
+  @Mock
+  private RuntimeService runtimeServiceMock;
+
+  @Test
+  public void should_not_throw_stubbing_exception_on_only_single_result() {
+
+    // GIVEN
+    CamundaMockito.mockProcessInstanceQuery(runtimeServiceMock)
+                  .singleResult(mock(ProcessInstance.class));
+
+    // WHEN
+    final ProcessInstance result = runtimeServiceMock.createProcessInstanceQuery()
+                                                     .processInstanceId("test")
+                                                     .singleResult();
+    // THEN
+    assertThat(result).isNotNull();
+  }
+
+  @Test
+  public void should_not_throw_stubbing_exception_on_only_list() {
+
+    // GIVEN
+    CamundaMockito.mockProcessInstanceQuery(runtimeServiceMock)
+                  .list(Lists.newArrayList(mock(ProcessInstance.class)));
+
+    // WHEN
+    final List<ProcessInstance> result = runtimeServiceMock.createProcessInstanceQuery()
+                                                           .processInstanceId("test")
+                                                           .list();
+    // THEN
+    assertThat(result).isNotNull();
+  }
+}

--- a/src/test/java/org/camunda/bpm/extension/mockito/query/TaskQueryMockTest.java
+++ b/src/test/java/org/camunda/bpm/extension/mockito/query/TaskQueryMockTest.java
@@ -1,25 +1,30 @@
 package org.camunda.bpm.extension.mockito.query;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-
-import java.util.Date;
-
 import org.camunda.bpm.engine.TaskService;
 import org.camunda.bpm.engine.task.Task;
 import org.camunda.bpm.engine.task.TaskQuery;
-//import org.camunda.bpm.extension.mockito.QueryMocks1;
 import org.camunda.bpm.extension.mockito.CamundaMockito;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+//import org.camunda.bpm.extension.mockito.QueryMocks1;
+
+@RunWith(MockitoJUnitRunner.class)
 public class TaskQueryMockTest {
 
-  private final TaskService taskService = mock(TaskService.class);
+  @Mock
+  private TaskService taskService;
 
-  private final Task singleResult = mock(Task.class);
+  @Mock
+  private Task singleResult;
 
   @Test
   public void should_mock_query_and_return_singleResult() {


### PR DESCRIPTION
Fixes issue #96 

The issue is caused by usage of MockitoJUnitRunner instead of `mock()` method. The runner initializes all mocks in strict mode whereas in mockito 2.21.0 `mock()` creates mocks in lenient mode by default. The call to `list()` in the constructor of `AbstractQueryMock` is regarded as stubbing. When `list()` is not called in the specific test, mockito throws the `UnnecessaryStubbingException`.

The calls to `list()` and `singleResult()` are unnecessary because stubbed "List returning"-Methods do already return an empty collection by default (see https://static.javadoc.io/org.mockito/mockito-core/2.21.0/org/mockito/Mockito.html#2). 